### PR TITLE
Add sshpass to ansible-tools image

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following table shows a quick overview of provided libraries and tools for e
 | Flavour | Based on | Additional Python libs | Additional binaries |
 |---------|---------------|------------------------|---------------------|
 | base    | -        | `cffi`, `cryptography`, `Jinja2`, `junit-xml`, `lxml`, `paramiko`, `PyYAML` | - |
-| tools   | base     | `dnspython`, `JMESPath`, `mitogen` | `bash`, `git`, `gpg`, `jq`, `ssh`, `yq` |
+| tools   | base     | `dnspython`, `JMESPath`, `mitogen` | `bash`, `git`, `gpg`, `jq`, `ssh`, `sshpass`, `yq` |
 | infra   | tools    | `docker`, `docker-compose`, `jsondiff`, `netaddr`, `pexpect`, `psycopg2`, `pyldap`, `pypsexec`, `pymongo`, `PyMySQL`, `pywinrm`, `smbprotocol` | `rsync`, `sshpass` |
 | azure   | tools    | `azure-*`              | `az` |
 | aws     | tools    | `awscli`, `botocore`, `boto`, `boto3` | `aws`, `aws-iam-authenticator` |


### PR DESCRIPTION
## Summary
- include `sshpass` in ansible-tools Dockerfile so password auth can be used
- document that `sshpass` is now part of `tools` flavour

## Testing
- `make test` *(fails: `docker: not found`)*
- `make lint` *(fails: `docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b515d618832c83847ba58276662b